### PR TITLE
Users/egelliott3/backup cleanup and logging refinement

### DIFF
--- a/MinecraftBdsManager/Configuration/BackupSettings.cs
+++ b/MinecraftBdsManager/Configuration/BackupSettings.cs
@@ -14,8 +14,8 @@
 
         public bool OnlyBackupIfUsersWereOnline { get; set; } = true;
 
-        public int KeepLastNumberOfBackups { get; set; } = 5;
+        public int KeepBackupsForNumberOfDays { get; set; } = 2;
 
-        public int KeepLastNumberOfDailyBackups { get; set; } = 7;
+        public int KeepDailyBackupsForNumberOfDays { get; set; } = 7;
     }
 }

--- a/MinecraftBdsManager/Configuration/LoggingSettings.cs
+++ b/MinecraftBdsManager/Configuration/LoggingSettings.cs
@@ -6,6 +6,6 @@
 
         public string FileLoggingDirectoryPath { get; set; } = @".\";
 
-        public int MaximumNumberOfLogFilesToKeep { get; set; } = 5;
+        public int KeepLogsForNumberOfDays { get; set; } = 3;
     }
 }

--- a/MinecraftBdsManager/frmMain.cs
+++ b/MinecraftBdsManager/frmMain.cs
@@ -42,12 +42,6 @@ namespace MinecraftBdsManager
             //  Need one for the log monitor, which will always be present
             LogManager.RegisterLogMonitor();
 
-            //  Need another one for log files, if opted in with valid path
-            if (Settings.CurrentSettings.LoggingSettings.EnableLoggingToFile)
-            {
-                LogManager.RegisterFileLogger(Settings.CurrentSettings.LoggingSettings.FileLoggingDirectoryPath);
-            }
-
             // If autostart is enabled then start the server
             if (Settings.CurrentSettings.AutoStartBedrockDedicatedServer)
             {
@@ -100,6 +94,12 @@ namespace MinecraftBdsManager
             if (_clearStatusBoxOnStart)
             {
                 rtbStatus.Clear();
+            }
+
+            //  If the user has asked for log files, create a new log file per start
+            if (Settings.CurrentSettings.LoggingSettings.EnableLoggingToFile)
+            {
+                LogManager.RegisterFileLogger(Settings.CurrentSettings.LoggingSettings.FileLoggingDirectoryPath, unregisterExistingListener: true);
             }
 
             if (Settings.CurrentSettings.BackupSettings.BackupOnServerStart)


### PR DESCRIPTION
Moved file logger to register on server start instead of app start.  That way there is a new log instance per server start instead of app start

updated keep/delete logic of logs and backups to be date based solely instead of count based since most systems use this kind of approach and it should be more inuitive to users.

Some method reordering in BackupManager

Added logic for creating a Daily backup folder in addition to the regular ones.