### PR TITLE
Added framework for an upgrade BDS screen

### DIFF
--- a/MinecraftBdsManager/Managers/LogManager.cs
+++ b/MinecraftBdsManager/Managers/LogManager.cs
@@ -95,11 +95,10 @@ namespace MinecraftBdsManager.Managers
 
         public static void RegisterUILogger(RichTextBox richTextBox, string listenerName = "RichTextBoxLogger", bool unregisterExistingListener = false)
         {
-            if (Trace.Listeners[listenerName] != null || unregisterExistingListener)
+            if (unregisterExistingListener)
             {
-                Trace.Listeners.Remove(listenerName);
+                UnregisterUILogger(richTextBox, listenerName);
             }
-
 
             if (Trace.Listeners[listenerName] == null)
             {
@@ -127,6 +126,14 @@ namespace MinecraftBdsManager.Managers
                 {
                     logInfo.Delete();
                 }
+            }
+        }
+
+        public static void UnregisterUILogger(RichTextBox richTextBox, string listenerName = "RichTextBoxLogger")
+        {
+            if (Trace.Listeners[listenerName] != null)
+            {
+                Trace.Listeners.Remove(listenerName);
             }
         }
     }

--- a/MinecraftBdsManager/frmMain.Designer.cs
+++ b/MinecraftBdsManager/frmMain.Designer.cs
@@ -72,6 +72,7 @@
             this.toolBtnSettings.Size = new System.Drawing.Size(34, 28);
             this.toolBtnSettings.Text = "toolStripButton1";
             this.toolBtnSettings.ToolTipText = "Minecraft BDS Manager Settings";
+            this.toolBtnSettings.Click += new System.EventHandler(this.toolBtnSettings_Click);
             // 
             // toolBtnStart
             // 

--- a/MinecraftBdsManager/frmMain.cs
+++ b/MinecraftBdsManager/frmMain.cs
@@ -1,5 +1,6 @@
 ﻿using MinecraftBdsManager.Configuration;
 using MinecraftBdsManager.Managers;
+using System.Reflection;
 
 namespace MinecraftBdsManager
 {
@@ -30,6 +31,10 @@ namespace MinecraftBdsManager
 
         private void frmMain_Load(object sender, EventArgs e)
         {
+            // Get version number so we can show it in the title.
+            Version version = Assembly.GetExecutingAssembly().GetName().Version!;
+            this.Text = String.Concat(this.Text, $" {version.Major}.{version.Minor}.{version.Build}");
+
             // Get those settings so we know how to handle things
             _ = Settings.LoadSettings();
 
@@ -120,6 +125,12 @@ namespace MinecraftBdsManager
             }
 
             ProcessManager.StartProcess(ProcessName.FireAndForget, "explorer.exe", LogManager.CurrentLogFilePath);
+        }
+
+        private void toolBtnSettings_Click(object sender, EventArgs e)
+        {
+            var frmSettings = new frmSettings();
+            frmSettings.ShowDialog();
         }
     }
 }

--- a/MinecraftBdsManager/frmSettings.Designer.cs
+++ b/MinecraftBdsManager/frmSettings.Designer.cs
@@ -29,20 +29,61 @@
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(frmSettings));
+            this.dlgOpenBdsZip = new System.Windows.Forms.OpenFileDialog();
+            this.btnPickUpgradeFile = new System.Windows.Forms.Button();
+            this.rtbStatus = new System.Windows.Forms.RichTextBox();
             this.SuspendLayout();
+            // 
+            // dlgOpenBdsZip
+            // 
+            this.dlgOpenBdsZip.FileName = "dlgOpenBdsZip";
+            this.dlgOpenBdsZip.Filter = "Zip files (*.zip)|*.zip";
+            // 
+            // btnPickUpgradeFile
+            // 
+            this.btnPickUpgradeFile.Location = new System.Drawing.Point(12, 12);
+            this.btnPickUpgradeFile.Name = "btnPickUpgradeFile";
+            this.btnPickUpgradeFile.Size = new System.Drawing.Size(184, 34);
+            this.btnPickUpgradeFile.TabIndex = 0;
+            this.btnPickUpgradeFile.Text = "Pick Upgrade File";
+            this.btnPickUpgradeFile.UseVisualStyleBackColor = true;
+            this.btnPickUpgradeFile.Click += new System.EventHandler(this.btnPickUpgradeFile_Click);
+            // 
+            // rtbStatus
+            // 
+            this.rtbStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.rtbStatus.BackColor = System.Drawing.SystemColors.ControlLight;
+            this.rtbStatus.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.rtbStatus.Location = new System.Drawing.Point(12, 52);
+            this.rtbStatus.Name = "rtbStatus";
+            this.rtbStatus.ReadOnly = true;
+            this.rtbStatus.Size = new System.Drawing.Size(1025, 579);
+            this.rtbStatus.TabIndex = 1;
+            this.rtbStatus.Text = "";
+            this.rtbStatus.TextChanged += new System.EventHandler(this.rtbStatus_TextChanged);
             // 
             // frmSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(10F, 25F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(1049, 643);
+            this.Controls.Add(this.rtbStatus);
+            this.Controls.Add(this.btnPickUpgradeFile);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "frmSettings";
-            this.Text = "Minecraft BDS Manager Settings";
+            this.Text = "Minecraft BDS Manager Server Upgrade Tool";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.frmSettings_FormClosing);
+            this.Load += new System.EventHandler(this.frmSettings_Load);
             this.ResumeLayout(false);
 
         }
 
         #endregion
+
+        private OpenFileDialog dlgOpenBdsZip;
+        private Button btnPickUpgradeFile;
+        private RichTextBox rtbStatus;
     }
 }

--- a/MinecraftBdsManager/frmSettings.cs
+++ b/MinecraftBdsManager/frmSettings.cs
@@ -1,8 +1,10 @@
-﻿using System;
+﻿using MinecraftBdsManager.Managers;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
+using System.IO.Compression;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -15,6 +17,59 @@ namespace MinecraftBdsManager
         public frmSettings()
         {
             InitializeComponent();
+        }
+
+        private async void btnPickUpgradeFile_Click(object sender, EventArgs e)
+        {
+            if (dlgOpenBdsZip.ShowDialog(this) == DialogResult.OK)
+            {
+                await UpgradeServerAsync(dlgOpenBdsZip.FileName);
+            }
+        }
+
+        private async Task UpgradeServerAsync(string zipFileName)
+        {
+            LogManager.LogInformation($"Performing BDS upgrade using the file {zipFileName}.");
+
+            string existingBdsFolder = Configuration.Settings.CurrentSettings.BedrockDedicateServerDirectoryPath;
+            if (!Directory.Exists(existingBdsFolder))
+            {
+                LogManager.LogError($"Current BDS folder {existingBdsFolder} does not exist.  Unable to upgrade server since it does not exist.");
+                return;
+            }
+
+            // Format the log filename to be "<worldName>_2009-06-15T134530Z" using UTC time and...
+            var formattedCurrentUtcDateTime = $"{DateTime.UtcNow:O}";
+
+            // ... taking out the colons (:) in order to not make Windows file system upset and...
+            formattedCurrentUtcDateTime = formattedCurrentUtcDateTime.Replace(":", string.Empty);
+
+            // ... remove the milliseconds/fractional seconds as they are not super useful and the plop the Z back on the end to keep the UTC signifier and...
+            formattedCurrentUtcDateTime = string.Concat(formattedCurrentUtcDateTime.Substring(0, formattedCurrentUtcDateTime.IndexOf(".")), "Z");
+
+
+            string bdsBackupFilePath = Path.GetFullPath(Path.Combine(existingBdsFolder, $"../BDS_Backup_{formattedCurrentUtcDateTime}.zip"));
+
+            ZipFile.CreateFromDirectory(existingBdsFolder, bdsBackupFilePath);
+
+
+        }
+
+        private void rtbStatus_TextChanged(object sender, EventArgs e)
+        {
+            rtbStatus.SelectionStart = rtbStatus.Text.Length;
+            rtbStatus.ScrollToCaret();
+        }
+
+        private void frmSettings_Load(object sender, EventArgs e)
+        {
+            // Register listener for traces from this dialog
+            LogManager.RegisterUILogger(rtbStatus, "UpgradeStatusBoxLogger");
+        }
+
+        private void frmSettings_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            LogManager.UnregisterUILogger(rtbStatus, "UpgradeStatusBoxLogger");
         }
     }
 }

--- a/MinecraftBdsManager/frmSettings.resx
+++ b/MinecraftBdsManager/frmSettings.resx
@@ -57,6 +57,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="dlgOpenBdsZip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="rtbStatus.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>True</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="$this.Icon" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>


### PR DESCRIPTION
Added logic and settings to support Cloud based backup.  Azure Blob backup copy is created with this commit and Amazon S3 is just stubbed.

Added code to show the BDS MAnager version in the title bar

Added a new toolbar icon to force map generation (assuming it's not already running)